### PR TITLE
Add support for serial job execution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,14 @@ The output of this state should pass along the input. It may contain additional 
 - `Parameters`: `{ Callback: { … }, Message: { … } }`
 - `OutputPath`: `$`, `{ Job: { … }, Artifact: { … }, TaskResults: [ … ], Void: [ … ] } }`
 
+### Job Serializer
+
+The job serializer is an iterator that comes into play if a job includes an `SerializedJobs`. It has no impact on the other aspects of the state machine execution, has no meaningful output, and only deals with the `SerializedJobs` that was originally defined on the input job message.
+
+- `InputPath`: `$`, `{ Job: { … }, Artifact: { … }, TaskResults: [ … ] }`
+- `Parameters`: `{ Execution: { … }, ExecutionTrace: [ … ], SerializedJob: { … } }`
+- `OutputPath`: `$`, `{ Job: { … }, Artifact: { … }, TaskResults: [ … ], Void: [ … ] } }`
+
 ### Output Normalization
 
 After callbacks have been sent, there's a final step that normalizes the output of the state machine. The resulting value is intended to match the message sent as part of each job callback.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,7 @@ The job serializer is an iterator that comes into play if a job includes an `Ser
 
 - `InputPath`: `$`, `{ Job: { … }, Artifact: { … }, TaskResults: [ … ] }`
 - `Parameters`: `{ Execution: { … }, ExecutionTrace: [ … ], SerializedJob: { … } }`
+- `ResultPath`: `$.Void`,  `{ Job: { … }, Artifact: { … }, TaskResults: [ … ], Void: [ … ] } }`
 - `OutputPath`: `$`, `{ Job: { … }, Artifact: { … }, TaskResults: [ … ], Void: [ … ] } }`
 
 ### Output Normalization

--- a/README.md
+++ b/README.md
@@ -235,6 +235,59 @@ If there's a failure during the job execution in any part of the state machine, 
 
 **Example:** If you have a job with three copy destinations, and two callbacks, you would expect to get a total of six `TaskResult` and two `JobResult` messages, across all of the endpoints.
 
+## Serialized Jobs
+
+A job can include any number of additional jobs that will be started after all tasks have succeeded. This allows you to easily perform tasks on files that resulted from an initial job.
+
+As an example, you may have a job with an MP2 source file and a transcode task that produces an MP3 version of that file. You could include a serialized job which then performs a transcribe task on that resulting MP3 file.
+
+Serialized jobs are **not** called recursively as part of the initial job execution. They are simply additional jobs that have their own state machine execution, and are entirely self-contained in their definition and execution. They have their own job ID, source, callbacks, tasks, etc, even additional serialized jobs. There is no inheritance from or referencing to the initial job or its outputs. The only benefit to using serialized jobs is that Porter provides the convenience of starting the job executions for you.
+
+If a job includes any serialized jobs, they are executed after all job result callbacks have been sent. Each serialized job is sent to the SNS topic mentioned previously. As such, the serialized executions are entirely decoupled from the initial execution. It will do nothing to ensure, and have no visibility into, the progress or success of the serialized jobs. Aside from this, including serialized jobs in a job has no impact on the job itself; callbacks will not indicate in any way that a job included serialized jobs, and individual tasks will not be aware of any of the future work that is expected to occur.
+
+When constructing jobs that include serialized jobs, it is constructor's responsibility to build sequential jobs with meaningful values. If the serialized job needs to do work on the result of the initial job's task, the two job definitions must be explicitly constructed in such a way that the resulting file of the task and the source file of the serialized job align.
+
+In some cases it could be acceptable or beneficial for a job and some of its serialized jobs to share a job ID, but this would depend enitrely on how the app that sent the job works, and how it handles the callbacks.
+
+When a job is started via this method, it will include an additional parameter in the definition called `ExecutionTrace`. This is array containing the execution ID of the job that started it, as well as the ID of the job that started that job, etc (if applicable). The last element in the array is the execution ID of the job that started the job being executed.
+
+All jobs included directly as members of `SerializedJobs` are started simultaneously.
+
+```
+{
+    "Job": {
+        "Id": "1234567890asdfghjkl",
+        "Source": {
+            "Mode": "AWS/S3",
+            "BucketName": "farski-sandbox-prx",
+            "ObjectKey": "130224.mp2"
+        },
+        "SerializedJobs": [
+            {
+                "Job": {
+                    "Id": "1234567890asdfghjkl",
+                    "Source": {
+                        "Mode": "AWS/S3",
+                        "BucketName": "farski-sandbox-prx",
+                        "ObjectKey": "130224.mp2"
+                    }
+                }
+            }, {
+                "Job": {
+                    "Id": "1234567890asdfghjkl",
+                    "Source": {
+                        "Mode": "AWS/S3",
+                        "BucketName": "farski-sandbox-prx",
+                        "ObjectKey": "130224.mp2"
+                    }
+                }
+            }
+        ]
+    }
+}
+
+```
+
 ## Tasks
 
 ### Copy

--- a/lambdas/JobSerializerLambdaFunction/index.js
+++ b/lambdas/JobSerializerLambdaFunction/index.js
@@ -1,0 +1,30 @@
+// A job definition can include serialized jobs. These are additional,
+// independent job definitions that will be started once the initial job has
+// completed all its tasks, and sent its job result callbacks.
+//
+// The serialized jobs are sent to an SNS topic, and the actual Step Function
+// execution initialization in handled elsewhere (by the
+// JobExecutionSnsTopicLambdaFunction).
+//
+// An ExecutionTrace is appended to the serialized job definition, which
+// represents the execution IDs of the jobs that serialized other jobs prior to
+// this one.
+
+const AWSXRay = require('aws-xray-sdk');
+
+const AWS = AWSXRay.captureAWS(require('aws-sdk'));
+
+const sns = new AWS.SNS({ apiVersion: '2010-03-31' });
+
+exports.handler = async (event) => {
+  console.log(JSON.stringify({ msg: 'State input', input: event }));
+
+  event.SerializedJob.ExecutionTrace = [...event.ExecutionTrace, event.Execution.Id];
+
+  console.log(JSON.stringify({ msg: 'Serialized Job', input: event.SerializedJob }));
+
+  await sns.publish({
+    TopicArn: process.env.JOB_EXECUTION_SNS_TOPIC_ARN,
+    Message: JSON.stringify(event.SerializedJob),
+  }).promise();
+};

--- a/lambdas/NormalizeInputLambdaFunction/index.js
+++ b/lambdas/NormalizeInputLambdaFunction/index.js
@@ -35,6 +35,16 @@ exports.handler = async (event) => {
     event.Job.Callbacks = [];
   }
 
+  // Set Job.SerializedJobs to an empty array, unless it's already an array.
+  if (!event.Job.hasOwnProperty('SerializedJobs') || !Array.isArray(event.Job.SerializedJobs)) {
+    event.Job.SerializedJobs = [];
+  }
+
+  // Set Job.ExecutionTrace to an empty array, unless it's already an array.
+  if (!event.Job.hasOwnProperty('ExecutionTrace') || !Array.isArray(event.Job.ExecutionTrace)) {
+    event.Job.ExecutionTrace = [];
+  }
+
   console.log(JSON.stringify({ msg: 'Normalized input', event: event }));
 
   return event;

--- a/template.yml
+++ b/template.yml
@@ -1398,6 +1398,85 @@ Resources:
       Dimensions:
         - Name: FunctionName
           Value: !Ref CallbackLambdaFunction
+  # Job Serializer Lambda
+  JobSerializerLambdaIamRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+            - Effect: Allow
+              Principal:
+                Service:
+                  - lambda.amazonaws.com
+              Action:
+                - sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
+      Policies:
+        - PolicyName: SnsPublishJobExecutionPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - sns:Publish
+                Resource:
+                  - !Ref JobExecutionSnsTopic
+      Tags:
+        - Key: Project
+          Value: Porter
+        - Key: prx:cloudformation:stack-name
+          Value: !Ref AWS::StackName
+        - Key: prx:cloudformation:stack-id
+          Value: !Ref AWS::StackId
+  JobSerializerLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: lambdas/JobSerializerLambdaFunction/
+      Description: >-
+        Serialized Porter jobs
+      Environment:
+        Variables:
+          JOB_EXECUTION_SNS_TOPIC_ARN: !Ref JobExecutionSnsTopic
+      Handler: index.handler
+      Layers:
+        - !Ref AwsXraySdkLambdaLayerVersionArn
+      MemorySize: 128
+      Role: !GetAtt JobSerializerLambdaIamRole.Arn
+      Runtime: nodejs12.x
+      Tags:
+        Project: Porter
+        prx:cloudformation:stack-name: !Ref AWS::StackName
+        prx:cloudformation:stack-id: !Ref AWS::StackId
+      Timeout: 4
+      Tracing: Active
+  JobSerializerLambdaErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: CreateProductionResources
+    Properties:
+      ActionsEnabled: true
+      AlarmName: "[Porter][Serialize][Lambda] Elevated error volume"
+      AlarmActions:
+        - !Ref OpsErrorMessagesSnsTopicArn
+      InsufficientDataActions:
+        - !Ref OpsErrorMessagesSnsTopicArn
+      OKActions:
+        - !Ref OpsErrorMessagesSnsTopicArn
+      AlarmDescription: >-
+        Job serializer function has encountered an invocation error
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      MetricName: LambdaFunctionsFailed
+      Namespace: AWS/States
+      Period: 60
+      Statistic: Sum
+      Threshold: 0
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref JobSerializerLambdaFunction
   # Normalize Output Lambda
   NormalizeOutputLambdaIamRole:
     Type: AWS::IAM::Role
@@ -1499,6 +1578,7 @@ Resources:
                   - !GetAtt CallbackLambdaFunction.Arn
                   - !GetAtt TranscodeTaskOutputLambdaFunction.Arn
                   - !GetAtt NormalizeOutputLambdaFunction.Arn
+                  - !GetAtt JobSerializerLambdaFunction.Arn
         - PolicyName: PassRoleToEcsPolicy
           PolicyDocument:
             Version: "2012-10-17"
@@ -2000,7 +2080,7 @@ Resources:
                   },
                   "ResultPath": "$.Void",
                   "OutputPath": "$",
-                  "Next": "NormalizeOutput",
+                  "Next": "StartSerializedJobs",
                   "MaxConcurrency": 0,
                   "Iterator": {
                     "StartAt": "SendJobCompleteCallback",
@@ -2010,6 +2090,43 @@ Resources:
                         "Comment": "Sends a callback message to a single endpoint in the iterator with a job result",
                         "InputPath": "$",
                         "Resource": "${CallbackLambdaFunctionArn}",
+                        "ResultPath": "$",
+                        "OutputPath": "$",
+                        "End": true,
+                        "Retry": [
+                          {
+                            "ErrorEquals": ["States.ALL"],
+                            "IntervalSeconds": 5,
+                            "MaxAttempts": 3,
+                            "BackoffRate": 2
+                          }
+                        ]
+                      }
+                    }
+                  }
+                },
+                "StartSerializedJobs": {
+                  "Type": "Map",
+                  "Comment": "Iterates over all serialized jobs and sends them to SNS",
+                  "InputPath": "$",
+                  "ItemsPath": "$.Job.SerializedJobs",
+                  "Parameters": {
+                    "Execution": { "Id.$": "$$.Execution.Id" },
+                    "ExecutionTrace.$": "$.Job.ExecutionTrace",
+                    "SerializedJob.$": "$$.Map.Item.Value"
+                  },
+                  "ResultPath": "$.Void",
+                  "OutputPath": "$",
+                  "Next": "NormalizeOutput",
+                  "MaxConcurrency": 0,
+                  "Iterator": {
+                    "StartAt": "StartSerializedJobExecution",
+                    "States": {
+                      "StartSerializedJobExecution": {
+                        "Type": "Task",
+                        "Comment": "Sends a serialized job to the job execution SNS topic",
+                        "InputPath": "$",
+                        "Resource": "${JobSerializerLambdaFunctionArn}",
                         "ResultPath": "$",
                         "OutputPath": "$",
                         "End": true,
@@ -2098,6 +2215,7 @@ Resources:
             EcsClusterArn: !GetAtt EcsCluster.Arn
             TranscodeEcsTaskDefinitionArn: !Ref TranscodeEcsTaskDefinition
             TranscodeTaskOutputLambdaFunctionArn: !GetAtt TranscodeTaskOutputLambdaFunction.Arn
+            JobSerializerLambdaFunctionArn: !GetAtt JobSerializerLambdaFunction.Arn
             VpcSubnet1: !Ref Subnet1
             VpcSubnet2: !Ref Subnet2
             TranscodeContainerName: !Sub ${AWS::StackName}-transcode-container


### PR DESCRIPTION
This implements a very lightweight approach to serializing or chaining jobs, providing support for running tasks against the results of other tasks.

The README has a thorough explanation of how this works, but the tl;dr is that this does **basically nothing**. It just lets you define several jobs in a single call to Porter, and when the state machine finishes the first one, it will start execution of the other ones. It's effectively the same as writing code on the app side that get's a callback and starts another execution. This just makes it more convenient, because the app only has to make one call to Porter, and then wait for all the results to show up.

While this does redirect some of the work to the client apps to construct more complex job messages, I think it provides a lot of additional flexibility for how apps can use Porter for ~30 LoC, and doesn't really add any additional complexity to how Porter itself operates. And, I don't think the work needed from the clients is actually that much more than if it were creating new jobs from callbacks; it just looks a little messier because the JSON message starts to get big in some cases.

My preference is to keep Porter simple (not adding true recursion, etc), and keep the message format simple (not adding reference tokens or interpolation that could link outputs and inputs), even if it means sometimes the messages get big.

Closes #22 