### PR TITLE
Improve handling of malformed tasks

### DIFF
--- a/lambdas/NormalizeInputLambdaFunction/index.js
+++ b/lambdas/NormalizeInputLambdaFunction/index.js
@@ -22,6 +22,12 @@ exports.handler = async (event) => {
 
   // Make sure all Transcode tasks have all three FFmpeg options
   event.Job.Tasks.forEach((task) => {
+    // The state machine definition expects each task to have a Type property,
+    // all fails without the error being caught if it's missing. This forces
+    // the execution to error in a way that can be caught and handled as
+    // expected. (Choice states don't support Catch)
+    if (!task.hasOwnProperty('Type')) { throw new Error('Job included a task without a Type'); }
+
     if (task.Type !== 'Transcode') { return; }
 
     if (!task.hasOwnProperty('FFmpeg')) { task.FFmpeg = {}; }
@@ -38,4 +44,4 @@ exports.handler = async (event) => {
   console.log(JSON.stringify({ msg: 'Normalized input', event: event }));
 
   return event;
-}
+};

--- a/lambdas/NormalizeInputLambdaFunction/index.js
+++ b/lambdas/NormalizeInputLambdaFunction/index.js
@@ -23,8 +23,8 @@ exports.handler = async (event) => {
   // Make sure all Transcode tasks have all three FFmpeg options
   event.Job.Tasks.forEach((task) => {
     // The state machine definition expects each task to have a Type property,
-    // all fails without the error being caught if it's missing. This forces
-    // the execution to error in a way that can be caught and handled as
+    // and fails without the error being caught if it's missing. This forces
+    // the execution to error out in a way that can be caught and handled as
     // expected. (Choice states don't support Catch)
     if (!task.hasOwnProperty('Type')) { throw new Error('Job included a task without a Type'); }
 

--- a/template.yml
+++ b/template.yml
@@ -1578,9 +1578,9 @@ Resources:
                   "Retry": [
                     {
                       "ErrorEquals": ["States.ALL"],
-                      "IntervalSeconds": 5,
-                      "MaxAttempts": 3,
-                      "BackoffRate": 2
+                      "IntervalSeconds": 1,
+                      "MaxAttempts": 2,
+                      "BackoffRate": 1
                     }
                   ],
                   "Catch": [


### PR DESCRIPTION
Closes #53 

Per the discussion yesterday in preening, this looks for tasks that are missing a `Type` property, and causes the input normalization step to fail. Failing within the state, rather than letting the state machine fail when it can't find the `Type`, allows the error to be caught, and for error callbacks to be sent.

This also lowers the number of retries and back off of the input normalize step. If it fails once, it's going to fail again since the input won't have changed. The only reason to retry is if Lambda stalled, and that can almost always be retried ASAP.