### PR TITLE
Run ffprobe on transcode task output and expose some values

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,6 +616,8 @@ The `FFmpeg` property is optional. When included, each of `GlobalOptions`, `Inpu
 
 For `AWS/S3` destinations, the contents of `Parameters` are passed directly to the [upload_file()](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.upload_file) method as `ExtraArgs`. S3 will default the `content-type` to `binary/octet-stream`, so you may generally want to define that parameter.
 
+The output for the task includes the destination bucket, object key, transcoded file size in bytes, and duration in milliseconds (see example below).
+
 Input:
 
 ```json
@@ -644,7 +646,9 @@ Output:
 {
     "Task": "Transcode",
     "BucketName": "myBucket",
-    "ObjectKey": "myObject.flac"
+    "ObjectKey": "myObject.flac",
+    "Duration": 23222.857,
+    "Size": 186035
 }
 ```
 

--- a/containers/transcode/transcode.py
+++ b/containers/transcode/transcode.py
@@ -5,6 +5,7 @@
 # STATE_MACHINE_NAME
 # STATE_MACHINE_EXECUTION_ID
 # STATE_MACHINE_JOB_ID
+# STATE_MACHINE_TASK_INDEX
 # STATE_MACHINE_S3_DESTINATION_WRITER_ROLE
 # STATE_MACHINE_AWS_REGION
 # STATE_MACHINE_ARTIFACT_BUCKET_NAME
@@ -73,6 +74,31 @@ if os.system(ffmpeg_cmd) != 0:
 
 end_time = time.time()
 duration = end_time - start_time
+
+# Probe the output of the transcode
+ffprobe_cmd = ' '.join([
+    "./ffmpeg-git-20200504-amd64-static/ffprobe",
+    "-v error",
+    "-show_streams",
+    "-show_format",
+    "-i output.file"
+    "-print_format json",
+    "> ffprobe.json"
+])
+
+if os.system(ffprobe_cmd) != 0:
+    raise Exception('FFmpeg probe failed')
+
+# Write the probe output to S3
+print('Writing probe output to S3 artifact bucket')
+s3.meta.client.upload_file(
+    'ffprobe.json',
+    os.environ['STATE_MACHINE_ARTIFACT_BUCKET_NAME'],
+    "{x}/transcode/ffprobe-{t}.json".format(
+        x=os.environ['STATE_MACHINE_EXECUTION_ID'],
+        t=os.environ['STATE_MACHINE_TASK_INDEX']
+    )
+)
 
 # Record transcode duration in CloudWatch Metrics
 cloudwatch.put_metric_data(

--- a/containers/transcode/transcode.py
+++ b/containers/transcode/transcode.py
@@ -55,7 +55,7 @@ s3.meta.client.download_file(
 
 # Execute the transcode
 ffmpeg_cmd = ' '.join([
-    "./ffmpeg-git-20200504-amd64-static/ffmpeg",
+    "./ffmpeg-git-20201128-amd64-static/ffmpeg",
     os.environ['STATE_MACHINE_FFMPEG_GLOBAL_OPTIONS'],
     "{i} -i artifact.file".format(
         i=os.environ['STATE_MACHINE_FFMPEG_INPUT_FILE_OPTIONS']
@@ -77,7 +77,7 @@ duration = end_time - start_time
 
 # Probe the output of the transcode
 ffprobe_cmd = ' '.join([
-    "./ffmpeg-git-20200504-amd64-static/ffprobe",
+    "./ffmpeg-git-20201128-amd64-static/ffprobe",
     "-v error",
     "-show_streams",
     "-show_format",

--- a/containers/transcode/transcode.py
+++ b/containers/transcode/transcode.py
@@ -81,7 +81,7 @@ ffprobe_cmd = ' '.join([
     "-v error",
     "-show_streams",
     "-show_format",
-    "-i output.file"
+    "-i output.file",
     "-print_format json",
     "> ffprobe.json"
 ])

--- a/lambdas/TranscodeTaskOutputLambdaFunction/index.js
+++ b/lambdas/TranscodeTaskOutputLambdaFunction/index.js
@@ -2,8 +2,23 @@
 // callback, this function takes the entire task input and builds a better
 // result that gets passed to the callback task.
 
+const AWSXRay = require('aws-xray-sdk');
+
+const AWS = AWSXRay.captureAWS(require('aws-sdk'));
+
+const s3 = new AWS.S3({ apiVersion: '2006-03-01' });
+
 exports.handler = async (event) => {
   console.log(JSON.stringify({ msg: 'State input', input: event }));
+
+  // Get ffprobe results
+  const file = await s3
+    .getObject({
+      Bucket: process.env.ARTIFACT_BUCKET_NAME,
+      Key: `${event.Execution.Id}/transcode/ffprobe-${event.TaskIteratorIndex}.json`,
+    })
+    .promise();
+  const ffprobe = JSON.parse(file.Body.toString());
 
   const now = new Date();
 
@@ -11,6 +26,8 @@ exports.handler = async (event) => {
     Task: event.Task.Type,
     BucketName: event.Task.Destination.BucketName,
     ObjectKey: event.Task.Destination.ObjectKey,
+    Duration: +ffprobe.format.duration * 1000,
+    Size: +ffprobe.format.size,
     Time: now.toISOString(),
     Timestamp: +now / 1000,
   };

--- a/state-machine.asl.json
+++ b/state-machine.asl.json
@@ -397,6 +397,10 @@
                         "Value.$": "$.Job.Id"
                       },
                       {
+                        "Name": "STATE_MACHINE_TASK_INDEX",
+                        "Value.$": "$.TaskIndex"
+                      },
+                      {
                         "Name": "STATE_MACHINE_S3_DESTINATION_WRITER_ROLE",
                         "Value": "${S3DestinationWriterRoleArn}"
                       },
@@ -483,7 +487,9 @@
             "InputPath": "$",
             "Parameters": {
               "Job": { "Id.$": "$.Job.Id" },
-              "Task.$": "$.Task"
+              "Execution": { "Id.$": "$$.Execution.Id" },
+              "Task.$": "$.Task",
+              "TaskIteratorIndex.$": "$.TaskIndex"
             },
             "ResultPath": "$.TaskResult",
             "OutputPath": "$",

--- a/state-machine.asl.json
+++ b/state-machine.asl.json
@@ -398,7 +398,7 @@
                       },
                       {
                         "Name": "STATE_MACHINE_TASK_INDEX",
-                        "Value.$": "$.TaskIndex"
+                        "Value.$": "States.Format('{}', $.TaskIndex)"
                       },
                       {
                         "Name": "STATE_MACHINE_S3_DESTINATION_WRITER_ROLE",

--- a/template.yml
+++ b/template.yml
@@ -1180,6 +1180,9 @@ Resources:
       ManagedPolicyArns:
         # Transcode operations are always pulling FROM the artifact bucket
         - !Ref ArtifactBucketReadOnlyAccessPolicy
+        # Also writing metadata to the artifact bucket for the output Lambda
+        # to read from
+        - !Ref ArtifactBucketWriteAccessPolicy
       Tags:
         - Key: Project
           Value: Porter
@@ -1901,6 +1904,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
         - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
+        - !Ref ArtifactBucketReadOnlyAccessPolicy
       Tags:
         - Key: Project
           Value: Porter

--- a/template.yml
+++ b/template.yml
@@ -1918,6 +1918,9 @@ Resources:
       CodeUri: lambdas/TranscodeTaskOutputLambdaFunction/
       Description: >-
         Formats the output of a transcode task result
+      Environment:
+        Variables:
+          ARTIFACT_BUCKET_NAME: !Ref ArtifactBucket
       Handler: index.handler
       Layers:
         - !Ref AwsXraySdkLambdaLayer


### PR DESCRIPTION
Closes #106 

Within the transcode Fargate (Docker) task, after `ffmpeg` has been run to produce a transcoded file, it will now also run `ffprobe` on that file (not the source file). The JSON output of that command is written to a file that's pushed to S3. The Lambda function that runs to produce task output for transcode tasks pulls that file and adds some basic data about the transcoded file to the task results.