### PR TITLE
Fix HTTP callbacks with redirects

### DIFF
--- a/lambdas/CallbackLambdaFunction/index.js
+++ b/lambdas/CallbackLambdaFunction/index.js
@@ -61,6 +61,7 @@ function httpRequest(event, message, redirectCount) {
           try {
             if (redirectCount > +process.env.MAX_HTTP_REDIRECTS) {
               reject(new Error('Too many redirects'));
+              return;
             }
 
             console.log(

--- a/lambdas/CallbackLambdaFunction/index.js
+++ b/lambdas/CallbackLambdaFunction/index.js
@@ -11,9 +11,9 @@ const sts = new AWS.STS({ apiVersion: '2011-06-15' });
 const cloudwatch = new AWS.CloudWatch({ apiVersion: '2010-08-01' });
 const eventbridge = new AWS.EventBridge({ apiVersion: '2015-10-07' });
 
-function httpRequest(event, message, redirectCount) {
+function httpRequest(event, message, redirectCount, redirectUrl) {
   return new Promise((resolve, reject) => {
-    const q = new URL(event.Callback.RedirectURL || event.Callback.URL);
+    const q = new URL(redirectUrl || event.Callback.URL);
 
     const options = {
       host: q.host,
@@ -73,8 +73,7 @@ function httpRequest(event, message, redirectCount) {
             );
 
             const count = redirectCount ? redirectCount + 1 : 1;
-            event.Callback.RedirectURL = res.headers.location;
-            await httpRequest(event, message, count);
+            await httpRequest(event, message, count, res.headers.location);
             resolve();
           } catch (error) {
             reject(error);

--- a/lambdas/CallbackLambdaFunction/index.js
+++ b/lambdas/CallbackLambdaFunction/index.js
@@ -40,7 +40,7 @@ function httpRequest(event, message, redirectCount) {
     options.headers['Content-Type'] = event.Callback['Content-Type'];
     options.headers['Content-Length'] = Buffer.byteLength(body);
 
-    const h = options.protocol === 'https:' ? https : http;
+    const h = q.protocol === 'https:' ? https : http;
     const req = h.request(options, (res) => {
       res.setEncoding('utf8');
 

--- a/lambdas/CallbackLambdaFunction/index.js
+++ b/lambdas/CallbackLambdaFunction/index.js
@@ -13,7 +13,7 @@ const eventbridge = new AWS.EventBridge({ apiVersion: '2015-10-07' });
 
 function httpRequest(event, message, redirectCount) {
   return new Promise((resolve, reject) => {
-    const q = new URL(event.Callback.URL);
+    const q = new URL(event.Callback.RedirectURL || event.Callback.URL);
 
     const options = {
       host: q.host,
@@ -73,7 +73,8 @@ function httpRequest(event, message, redirectCount) {
             );
 
             const count = redirectCount ? redirectCount + 1 : 1;
-            await httpRequest(res.headers.location, message, count);
+            event.Callback.RedirectURL = res.headers.location;
+            await httpRequest(event, message, count);
             resolve();
           } catch (error) {
             reject(error);


### PR DESCRIPTION
- Correctly check the protocol of the URL (I think all requests were previously being downgraded to HTTP)
- Return immediate when the max redirect limit is hit, to prevent excessive trying
- Don't pass a string when it's expecting an object