### PR TITLE
Fix active ftp

### DIFF
--- a/src/containers/ftp/ftp_files.rb
+++ b/src/containers/ftp/ftp_files.rb
@@ -89,10 +89,10 @@ class FtpFiles
 
       begin
         # this makes active mode work by sending the public ip of the client
-        ftp.local_host = public_ip if public_ip
+        ftp.public_host_ip = public_ip if public_ip
 
-        # this works around when a remote server doesn't send its public IP
-        ftp.override_local = true
+        # use_pasv_ip is false now by default. Uses the same IP for the command as for data
+        ftp.use_pasv_ip = false
 
         ftp.passive = passive
         ftp.binary = options[:binary].nil? ? true : options[:binary]

--- a/src/containers/ftp/ftp_files.rb
+++ b/src/containers/ftp/ftp_files.rb
@@ -24,7 +24,7 @@ class FtpFiles
   # - retry_wait: defaults to 10 seconds
   # - max_attempts: the number of times to try the transfer
   # - md5: will write an md5 by default, defaults to false
-  # - keep_alive: will attempt to keep connections alive by default, true
+  # - keep_alive: attempt to keep connections alive with a noop every  N seconds, 0 / off by default
   # - mode: FTP/Active, FTP/Passive, or FTP/Auto
   # - binary: binary transfer, true by default
   # - timeout: how long to spend trying to transfer the file
@@ -52,7 +52,7 @@ class FtpFiles
     md5_file = create_md5_digest(local_file.path) if md5
 
     # this may be turned to 0 on error
-    keep_alive = options[:keep_alive].nil? ? 10 : options[:keep_alive].to_i
+    keep_alive = options[:keep_alive].nil? ? 0 : options[:keep_alive].to_i
 
     max_attempts = options[:max_attempts] || 1
     retry_wait = options[:retry_wait] || 10

--- a/src/containers/ftp/ftp_patch.rb
+++ b/src/containers/ftp/ftp_patch.rb
@@ -1,70 +1,24 @@
 # frozen_string_literal: true
-
-require 'ipaddr'
 require 'net/ftp'
-
-# N.B. look at Socket AddrInfo stdlib, might be a better way to do this
-class IPAddr
-  IP4_PRIVATE_RANGES = [
-    IPAddr.new('10.0.0.0/8'),
-    IPAddr.new('172.16.0.0/12'),
-    IPAddr.new('192.168.0.0/16'),
-    IPAddr.new('127.0.0.0/8')
-  ].freeze
-
-  IP6_PRIVATE_RANGES = [IPAddr.new('fc00::/7'), IPAddr.new('::1')].freeze
-
-  def private?
-    ranges = ipv6? ? IP6_PRIVATE_RANGES : IP4_PRIVATE_RANGES
-    ranges.each { |ipr| return true if ipr.include?(self) }
-    false
-  end
-
-  def public?
-    !private?
-  end
-end
 
 module Net
   # Override the Net::FTP class to add overrides
+  #  - based on this closed patch: https://github.com/ruby/ruby/pull/1561
   class FTP
-    attr_accessor :remote_host
-
-    # set to override host when ftp server returns a private/loopback IP on PASV
-    attr_accessor :override_local
-
     # this makes active mode work by setting the public ip of the client
-    attr_accessor :local_host
+    attr_accessor :public_host_ip
 
-    def makepasv_with_override
-      host, port = makepasv_without_override
-      if remote_host
-        host = remote_host
-      elsif override_local && IPAddr.new(host).private?
-        # server sent a bad/private IP, use the remote IP from the connection
-        host = @sock.remote_address.ip_address
+    # override with the public_host_ip
+    def sendport_with_override(host, port)
+      if public_host_ip
+        host = public_host_ip
       end
-
-      [host, port]
+      sendport_without_override(host, port)
     end
 
     # rubocop:disable Style/Alias
-    alias_method :makepasv_without_override, :makepasv
-    alias_method :makepasv, :makepasv_with_override
-
-    def makeport_with_override
-      sock = TCPServer.open(@sock.addr[3], 0)
-      port = sock.addr[1]
-      # set the public ip for the client to receive connections to
-      host = local_host || sock.addr[3]
-
-      sendport(host, port)
-
-      sock
-    end
-
-    alias_method :makeport_without_override, :makeport
-    alias_method :makeport, :makeport_with_override
+    alias_method :sendport_without_override, :sendport
+    alias_method :sendport, :sendport_with_override
     # rubocop:enable Style/Alias
   end
 end

--- a/src/containers/ftp/ftp_patch.rb
+++ b/src/containers/ftp/ftp_patch.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'net/ftp'
 
 module Net
@@ -10,9 +11,7 @@ module Net
 
     # override with the public_host_ip
     def sendport_with_override(host, port)
-      if public_host_ip
-        host = public_host_ip
-      end
+      host = public_host_ip if public_host_ip
       sendport_without_override(host, port)
     end
 

--- a/test/acceptance/copy_test.rb
+++ b/test/acceptance/copy_test.rb
@@ -333,5 +333,33 @@ describe :porter do
         _(output['JobResult']['TaskResults'].length).must_equal 1
       end
     end
+
+    it 'returns execution output for an active FTP copy task' do
+      job = {
+        Job: {
+          Id: 'porter-test-copy-ftp-active',
+          Source: {
+            Mode: 'HTTP',
+            URL: 'https://dovetail.prxu.org/152/245d0fe2-4171-4ebf-bea3-69deff3e9336/input file with spaces.mp3'
+          },
+          Tasks: [
+            {
+              Type: 'Copy',
+              Mode: 'FTP/Active',
+              URL: 'ftp://dlpuser:rNrKYTX9g7z3RgJRmxWuGHbeu@ftp.dlptest.com/file.ext',
+              MaxAttempts: 1
+            }
+          ]
+        }
+      }
+
+      job_test(job, 10) do |output|
+        _(output['JobResult']['Job']['Id']).must_equal 'porter-test-copy-ftp-active'
+        _(output['JobResult']['State']).must_equal 'DONE'
+        _(output['JobResult']['FailedTasks']).must_equal []
+        _(output['JobResult']['TaskResults'].length).must_equal 1
+      end
+    end
+
   end
 end

--- a/test/acceptance/copy_test.rb
+++ b/test/acceptance/copy_test.rb
@@ -360,6 +360,5 @@ describe :porter do
         _(output['JobResult']['TaskResults'].length).must_equal 1
       end
     end
-
   end
 end

--- a/test/acceptance/copy_test.rb
+++ b/test/acceptance/copy_test.rb
@@ -333,32 +333,5 @@ describe :porter do
         _(output['JobResult']['TaskResults'].length).must_equal 1
       end
     end
-
-    it 'returns execution output for an active FTP copy task' do
-      job = {
-        Job: {
-          Id: 'porter-test-copy-ftp-active',
-          Source: {
-            Mode: 'HTTP',
-            URL: 'https://dovetail.prxu.org/152/245d0fe2-4171-4ebf-bea3-69deff3e9336/input file with spaces.mp3'
-          },
-          Tasks: [
-            {
-              Type: 'Copy',
-              Mode: 'FTP/Active',
-              URL: 'ftp://dlpuser:rNrKYTX9g7z3RgJRmxWuGHbeu@ftp.dlptest.com/file.ext',
-              MaxAttempts: 1
-            }
-          ]
-        }
-      }
-
-      job_test(job, 10) do |output|
-        _(output['JobResult']['Job']['Id']).must_equal 'porter-test-copy-ftp-active'
-        _(output['JobResult']['State']).must_equal 'DONE'
-        _(output['JobResult']['FailedTasks']).must_equal []
-        _(output['JobResult']['TaskResults'].length).must_equal 1
-      end
-    end
   end
 end


### PR DESCRIPTION
The Ruby version has a different implementation.
- This adds support for using the command port remote IP for data as well (even if a different port gets sent)
- and requires a new implementation of how to send the instance's public IP (e.g. for use on ec2 servers)
- Also - disable the default keep_alive messages, they seem to be causing problems for several stations

(The keep_alive may need to be configurable from the subscription, we'll see)