### PR TITLE
For Active FTP, override port

### DIFF
--- a/src/containers/ftp/ftp.rb
+++ b/src/containers/ftp/ftp.rb
@@ -6,13 +6,15 @@
 # STATE_MACHINE_ARN
 # STATE_MACHINE_NAME
 # STATE_MACHINE_EXECUTION_ID
-# STATE_MACHINE_FTP_LISTEN_PORT
 # STATE_MACHINE_JOB_ID
 # STATE_MACHINE_TASK_INDEX
 # STATE_MACHINE_AWS_REGION
 # STATE_MACHINE_ARTIFACT_BUCKET_NAME
 # STATE_MACHINE_ARTIFACT_OBJECT_KEY
 # STATE_MACHINE_TASK_JSON
+# Set elsewhere
+# FTP_LISTEN_PORT
+# PUBLIC_IP
 
 $stdout.sync = true
 $stderr.sync = true
@@ -62,7 +64,7 @@ begin
   file = s3_files.download_file(bucket, key)
 
   public_ip = ENV['PUBLIC_IP']
-  public_port = ENV['STATE_MACHINE_FTP_LISTEN_PORT']
+  public_port = ENV['FTP_LISTEN_PORT']
   task = JSON.parse(ENV['STATE_MACHINE_TASK_JSON'])
   uri = URI.parse(task['URL'])
   md5 = task['MD5'].nil? ? false : task['MD5']

--- a/src/containers/ftp/ftp_files.rb
+++ b/src/containers/ftp/ftp_files.rb
@@ -47,6 +47,7 @@ class FtpFiles
     cstr = anon_uri.to_s
 
     public_ip = options[:public_ip]
+    public_port = options[:public_port]
 
     md5 = options[:md5].nil? ? false : options[:md5]
     md5_file = create_md5_digest(local_file.path) if md5
@@ -66,6 +67,7 @@ class FtpFiles
       msg: 'FTP transfer setup',
       task_mode: options[:mode],
       public_ip: public_ip,
+      public_port: public_port,
       md5: md5,
       remote_host: remote_host,
       remote_port: remote_port,
@@ -88,8 +90,9 @@ class FtpFiles
       ftp = Net::FTP.new
 
       begin
-        # this makes active mode work by sending the public ip of the client
+        # this makes active mode work by sending the public ip and port of the client
         ftp.public_host_ip = public_ip if public_ip
+        ftp.public_port_num = public_port if public_port
 
         # use_pasv_ip is false now by default. Uses the same IP for the command as for data
         ftp.use_pasv_ip = false

--- a/src/containers/ftp/ftp_patch.rb
+++ b/src/containers/ftp/ftp_patch.rb
@@ -6,13 +6,28 @@ module Net
   # Override the Net::FTP class to add overrides
   #  - based on this closed patch: https://github.com/ruby/ruby/pull/1561
   class FTP
-    # this makes active mode work by setting the public ip of the client
-    attr_accessor :public_host_ip
+    # this makes active mode work by setting the public ip and port of the client
+    attr_accessor :public_host_ip, :public_port_num
 
-    # override with the public_host_ip
+    # override the listening port with public_port_num
+    def makeport_with_override
+      port = [public_port_num.to_i, 0].max
+      host = @bare_sock.local_address.ip_address
+      puts "Net::FTP Patch: makeport_with_override: #{host}:#{port}"
+      Addrinfo.tcp(host, port).listen
+    end
+
+    # rubocop:disable Style/Alias
+    alias_method :makeport_without_override, :makeport
+    alias_method :makeport, :makeport_with_override
+    # rubocop:enable Style/Alias
+
+    # override the host and port with public_host_ip and public_port_num
     def sendport_with_override(host, port)
-      host = public_host_ip if public_host_ip
-      sendport_without_override(host, port)
+      override_host = public_host_ip || host
+      override_port = [public_port_num.to_i, port.to_i].max
+      puts "Net::FTP Patch: sendport_with_override: default: #{host}:#{port}, override: #{override_host}:#{override_port}"
+      sendport_without_override(override_host, override_port)
     end
 
     # rubocop:disable Style/Alias

--- a/template.yml
+++ b/template.yml
@@ -1119,7 +1119,10 @@ Resources:
     Type: AWS::ECS::TaskDefinition
     Properties:
       ContainerDefinitions:
-        - Essential: true
+        - Environment:
+            - Name: FTP_LISTEN_PORT
+              Value: 32888
+          Essential: true
           Image: !Ref FtpCopyEcsTaskDefinitionImage
           LogConfiguration:
             LogDriver: awslogs
@@ -1128,6 +1131,9 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: ecs
           Name: !Sub ${AWS::StackName}-ftp-copy-container
+          PortMappings:
+            - ContainerPort: 32888
+              Protocol: tcp
       Cpu: "4096"
       ExecutionRoleArn: !GetAtt FtpCopyEcsTaskExecutionIamRole.Arn
       Memory: "8192"


### PR DESCRIPTION
- [x] Patch Net::FTP to set a port to send in PORT command and to then listen on
- [x] Pass in the port via an ENV VAR (i.e. from Porter)