### PR TITLE
Allow NoPadByte for wav wrap tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,6 +795,8 @@ Wrapping is performed by [prx-wavefile](https://github.com/PRX/prx-wavefile), an
 
 By default, the resulting WAV-wrapped file will include the `fmt`, `mext`, `bext`, `fact`, and `data` chunks, with data derived from the source file. The `Task.Chunks` array can also include explicitly-defined chunks, such as the `cart` chunk, as seen in the example below (i.e., `"ChunkId": "cart"`).
 
+`Task.NoPadByte` is optional, and defaults to `false` (meaning, by default, pad bytes are included, which adheres to the RIFF spec). `NoPadByte` is generally used for compatibility with software that incorrectly implement the RIFF spec and can't handle the pad bytes.
+
 The task output includes a `WavfileChunks` array, which includes only the chunks passed in to `Task.Chunks` _and_ were included in the resulting file. The chunks may include some attributes that were not listed in the input, as some default attributes are added to certain chunks during the WAV wrap process.
 
 Input:

--- a/README.md
+++ b/README.md
@@ -807,6 +807,7 @@ Input:
         "BucketName": "myBucket",
         "ObjectKey": "myTranscript.json"
     },
+    "NoPadByte": true,
     "Chunks": [
         {
             "ChunkId": "cart",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "@google-cloud/storage": "^5.18.3",
     "aws-sdk": "^2.1046.0",
     "file-type": "^15.0.0",
-    "prx-wavefile": "^11.0.0-prx.1",
-    "sharp": "^0.25.2",
-    "md5": "^2.3.0"
+    "md5": "^2.3.0",
+    "prx-wavefile": "^11.0.0-prx.4",
+    "sharp": "^0.25.2"
   },
   "devDependencies": {
     "@prettier/plugin-ruby": "^0.20.1",

--- a/src/lambdas/wav-wrap/index.js
+++ b/src/lambdas/wav-wrap/index.js
@@ -119,7 +119,7 @@ exports.handler = async (event) => {
   // create the wav object
   const wav = new wavefile.WaveFile();
 
-  // only if the task explicit turns off pad byte
+  // only if the task explicitly turns off pad byte
   if (event.Task.NoPadByte === true) {
     wav.padBytes = false;
   }

--- a/src/lambdas/wav-wrap/index.js
+++ b/src/lambdas/wav-wrap/index.js
@@ -119,6 +119,11 @@ exports.handler = async (event) => {
   // create the wav object
   const wav = new wavefile.WaveFile();
 
+  // only if the task explicit turns off pad byte
+  if (event.Task.NoPadByte === true) {
+    wav.padBytes = false;
+  }
+
   if (s3Object.Body instanceof Uint8Array || Buffer.isBuffer(s3Object.Body)) {
     wav.fromMpeg(s3Object.Body);
   } else {

--- a/test/unit/lambdas/WavWrapLambdaFunction.test.js
+++ b/test/unit/lambdas/WavWrapLambdaFunction.test.js
@@ -34,6 +34,7 @@ test('wraps an mp2', async () => {
         ObjectKey: 'wxyz/sound-opinions/30000.wav',
         ContentType: 'audio/wav',
       },
+      NoPadByte: true,
       Chunks: [
         {
           ChunkId: 'cart',


### PR DESCRIPTION
relies on changes to prx-wavefile, and messages from exchange