### PR TITLE
Add basic support for FTPS copy destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ Output:
 
 #### FTP
 
-FTP operations are handled in the FTP container, using Ruby's `Net::FTP` module.
+FTP operations are handled in the FTP container, using Ruby's `Net::FTP` and `Net::SFTP` modules.
 
 The `Mode` property can be one of `FTP/Passive`, `FTP/Active`, or `FTP/Auto`. When `FTP/Auto` is used, both passive and active modes will be used if necessary, in order to try to complete the transfer.
 
@@ -591,7 +591,9 @@ and useful to validate the file was transferred without error by checking the MD
 
 The task output will include a `Mode` value, which may not match the `Mode` value from the input. The output will indicate the FTP transfer mode that was actually used to sucessfully transfer the file. When `FTP/Auto` is selected for a task, this allows you to inspect which mode was used internally to complete the transfer.
 
-SFTP is also support when using an `sftp://` URL. All modes work identically with SFTP URLs, since there is no active or passive mode for SFTP. If included, the URL's port is ignored.
+FTPS is also supported when using an `ftps://` URL.
+
+SFTP is also supported when using an `sftp://` URL. All modes work identically with SFTP URLs, since there is no active or passive mode for SFTP. If included, the URL's port is ignored. Currently, not all timeout and retry options are honored when performing SFTP copy tasks.
 
 Input:
 

--- a/src/containers/ftp/ftp.rb
+++ b/src/containers/ftp/ftp.rb
@@ -72,7 +72,7 @@ begin
   # This value is not guaranteed to be honored, so it's undocumented
   max_attempts = task['MaxAttempts'].nil? ? 6 : task['MaxAttempts']
 
-  if uri.scheme == 'ftp'
+  if uri.scheme == 'ftp' || uri.scheme == 'ftps'
     ftp_files = FtpFiles.new(logger, recorder)
     ftp_options = {
       md5: md5,
@@ -80,7 +80,8 @@ begin
       public_port: public_port,
       mode: task['Mode'],
       timeout: timeout,
-      max_attempts: max_attempts
+      max_attempts: max_attempts,
+      use_tls: uri.scheme == 'ftps'
     }
     used_mode = ftp_files.upload_file(uri, file, ftp_options)
 

--- a/src/containers/ftp/ftp_files.rb
+++ b/src/containers/ftp/ftp_files.rb
@@ -55,6 +55,8 @@ class FtpFiles
     # this may be turned to 0 on error
     keep_alive = options[:keep_alive].nil? ? 0 : options[:keep_alive].to_i
 
+    use_tls = options[:use_tls].nil? ? false : options[:use_tls]
+
     max_attempts = options[:max_attempts] || 1
     retry_wait = options[:retry_wait] || 10
     attempt = 1
@@ -101,6 +103,7 @@ class FtpFiles
         ftp.binary = options[:binary].nil? ? true : options[:binary]
         ftp.open_timeout = nil # default is nil
         ftp.read_timeout = 60 # default is 60
+        ftp.ssl = options[:use_tls]
         # ftp.debug_mode = true
 
         begin


### PR DESCRIPTION
Allegedly FTPS has been supported by `Net/FTP` since Ruby 2.4.

This will upgrade to a TLS connection when the task's URL uses a `ftps://` scheme.

Required for https://github.com/PRX/exchange.prx.org/issues/640.

This code is untested.