### PR TITLE
Multipart copy

### DIFF
--- a/src/lambdas/ingest/source/aws-s3.js
+++ b/src/lambdas/ingest/source/aws-s3.js
@@ -130,7 +130,9 @@ export default async function main(event, artifact) {
 
   // S3 can perform a native copy of objects up to 5 GB using the CopyObject
   // API. For objects larger than 5 GB, a multi-part upload must be used.
-  if (head.ContentLength < 5000000000) {
+  // We use multi-part uploads for files over 50 MB
+  const MB = 10 ** 6; // 10^6 bytes = 1,000,000 B = 1 MB
+  if (head.ContentLength < 50 * MB) {
     // Copies an existing S3 object to the S3 artifact bucket.
     // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#copyObject-property
     // https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectCOPY.html

--- a/src/lambdas/ingest/source/aws-s3.js
+++ b/src/lambdas/ingest/source/aws-s3.js
@@ -130,9 +130,9 @@ export default async function main(event, artifact) {
 
   // S3 can perform a native copy of objects up to 5 GB using the CopyObject
   // API. For objects larger than 5 GB, a multi-part upload must be used.
-  // We use multi-part uploads for files over 50 MB
+  // We use multi-part uploads for files over 100 MB.
   const MB = 10 ** 6; // 10^6 bytes = 1,000,000 B = 1 MB
-  if (head.ContentLength < 50 * MB) {
+  if (head.ContentLength < 100 * MB) {
     // Copies an existing S3 object to the S3 artifact bucket.
     // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#copyObject-property
     // https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectCOPY.html


### PR DESCRIPTION
General consensus seems to be 100 MB as a breakpoint, but I don't think it's ever faster, it just requires fewer API calls (which I guess is technically cheaper) and is an atomic operation (which doesn't really matter to us in this case). So I could imagine using the multi-part copy for everything at some point. But sticking with convention for now.